### PR TITLE
[1.19.2] Split Nether ores into its own configured feature

### DIFF
--- a/src/main/resources/data/miningmaster/worldgen/configured_feature/ore_gem_random.json
+++ b/src/main/resources/data/miningmaster/worldgen/configured_feature/ore_gem_random.json
@@ -125,32 +125,6 @@
             "weight": 1
           }
         ]
-      },
-      {
-        "target": {
-          "predicate_type": "minecraft:tag_match",
-          "tag": "minecraft:base_stone_nether"
-        },
-        "states": [
-          {
-            "state": {
-              "Name": "miningmaster:power_pyrite_ore"
-            },
-            "weight": 1
-          },
-          {
-            "state": {
-              "Name": "miningmaster:kinetic_opal_ore"
-            },
-            "weight": 1
-          },
-          {
-            "state": {
-              "Name": "miningmaster:heart_rhodonite_ore"
-            },
-            "weight": 1
-          }
-        ]
       }
     ]
   },

--- a/src/main/resources/data/miningmaster/worldgen/configured_feature/ore_gem_random_nether.json
+++ b/src/main/resources/data/miningmaster/worldgen/configured_feature/ore_gem_random_nether.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "discard_chance_on_air_exposure": 0,
+    "targets": [
+      {
+        "target": {
+          "predicate_type": "minecraft:tag_match",
+          "tag": "minecraft:base_stone_nether"
+        },
+        "states": [
+          {
+            "state": {
+              "Name": "miningmaster:power_pyrite_ore"
+            },
+            "weight": 1
+          },
+          {
+            "state": {
+              "Name": "miningmaster:kinetic_opal_ore"
+            },
+            "weight": 1
+          },
+          {
+            "state": {
+              "Name": "miningmaster:heart_rhodonite_ore"
+            },
+            "weight": 1
+          }
+        ]
+      }
+    ]
+  },
+  "type": "miningmaster:ore_gem_feature"
+}

--- a/src/main/resources/data/miningmaster/worldgen/placed_feature/ore_gem_random_nether.json
+++ b/src/main/resources/data/miningmaster/worldgen/placed_feature/ore_gem_random_nether.json
@@ -1,5 +1,5 @@
 {
-  "feature": "miningmaster:ore_gem_random",
+  "feature": "miningmaster:ore_gem_random_nether",
   "placement": [
     {
       "type": "minecraft:count",


### PR DESCRIPTION
Currently, Mining Master has a single configured feature for ores, differentiated by block tag. Nether ores use the block tag `#minecraft:base_stone_nether` to determine if they should be placed in the placed feature. Unfortunately since the configured feature is applied to both the Overworld and The Nether, mods that add Overworld features or terrain with base stone Nether blocks may see Mining Master's ores appear in them. This PR fixes that by isolating the Nether ores configured feature into its own file.

Here you can see that Nether ores still spawn properly.

![Screenshot_20250118_181836](https://github.com/user-attachments/assets/783fb4b2-2a84-4314-99a9-73cd543d61cf)

- Fixes #64.

> [!CAUTION]
> Splitting off the Nether ores into its own features is a breaking change. Data packs that add to, or override, the current configured feature will not see their new Nether ores in the game if they do not use their own features.