### PR TITLE
[1.20.1] Fixed item tab and tooltip translations, customizable tooltips

### DIFF
--- a/src/main/java/org/infernalstudios/miningmaster/init/MMItems.java
+++ b/src/main/java/org/infernalstudios/miningmaster/init/MMItems.java
@@ -100,7 +100,7 @@ public class MMItems {
     public static final RegistryObject<CreativeModeTab> TAB = TABS.register("mining_master",
             () -> CreativeModeTab.builder()
                     .icon(() -> new ItemStack(TAB_ITEM.get()))
-                    .title(Component.literal("Mining Master"))
+                    .title(Component.translatable("itemGroup.MiningMasterTab"))
                     .displayItems((features, output) -> {
                         for (RegistryObject<Item> item : ITEMS.getEntries()) {
                             if (item != TAB_ITEM) output.accept(item.get());

--- a/src/main/java/org/infernalstudios/miningmaster/items/GemItem.java
+++ b/src/main/java/org/infernalstudios/miningmaster/items/GemItem.java
@@ -19,13 +19,18 @@ public class GemItem extends Item {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
         if (Screen.hasShiftDown()) {
-            tooltip.add(
-                Language.getInstance().has(this.getDescriptionId() + ".tooltip") ?
-                    Component.translatable(this.getDescriptionId() + ".tooltip") :
-                    Component.translatable("miningmaster.item.tooltip.fallback_gem")
-            );
+            String tooltipText = this.getTooltipText().getString();
+            for (String line : tooltipText.split("\n")) {
+                tooltip.add(Component.literal(line));
+            }
         } else {
             tooltip.add(Component.translatable("miningmaster.item.tooltip.hold_shift"));
         }
+    }
+
+    private Component getTooltipText() {
+        return Language.getInstance().has(this.getDescriptionId() + ".tooltip") ?
+            Component.translatable(this.getDescriptionId() + ".tooltip") :
+            Component.translatable("miningmaster.item.tooltip.fallback_gem");
     }
 }

--- a/src/main/java/org/infernalstudios/miningmaster/items/GemItem.java
+++ b/src/main/java/org/infernalstudios/miningmaster/items/GemItem.java
@@ -1,6 +1,7 @@
 package org.infernalstudios.miningmaster.items;
 
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -15,14 +16,16 @@ public class GemItem extends Item {
         super(new Item.Properties());
     }
 
-
-
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
         if (Screen.hasShiftDown()) {
-            tooltip.add(Component.literal("\u00A7dCombine with an item in a smithing table to enchant!"));
+            tooltip.add(
+                Language.getInstance().has(this.getDescriptionId() + ".tooltip") ?
+                    Component.translatable(this.getDescriptionId() + ".tooltip") :
+                    Component.translatable("miningmaster.item.tooltip.fallback_gem")
+            );
         } else {
-            tooltip.add(Component.literal("\u00A78Hold Shift for Instructions"));
+            tooltip.add(Component.translatable("miningmaster.item.tooltip.hold_shift"));
         }
     }
 }

--- a/src/main/resources/assets/miningmaster/lang/en_us.json
+++ b/src/main/resources/assets/miningmaster/lang/en_us.json
@@ -84,6 +84,9 @@
   "item.miningmaster.paragon_leggings": "Paragon Leggings",
   "item.miningmaster.paragon_boots": "Paragon Boots",
 
+  "miningmaster.item.tooltip.hold_shift": "\u00A78Hold [SHIFT] for more info",
+  "miningmaster.item.tooltip.fallback_gem": "\u00A7dCombine with an item in a smithing table to enchant!",
+
   "miningmaster:container.gem_forge": "Gem Forge",
 
   "miningmaster.advancements.miningmaster.root.title": "Mining Master",
@@ -203,7 +206,6 @@
 
   "miningmaster.config.option.randomGemsPerChunk": "Random Gem Spawns Per Chunk",
   "miningmaster.config.tooltip.randomGemsPerChunk": "Determines how many times a random gem ore will attempt to spawn per chunk. REQUIRES RESTART.",
-
 
   "enchantment.miningmaster.freezing": "Freezing",
   "enchantment.miningmaster.freezing.desc": "Inflicts Slowness on hit. Also deals extra damage to fire-based entities.",


### PR DESCRIPTION
Made the creative item tab correctly use the lang entry for its name, moved item tooltips into lang entries, and added optional tooltip customization for modpack devs.

![Screenshot_20250224_213534](https://github.com/user-attachments/assets/8938f728-193c-4635-89a2-46462eddb2d0)
You still need to press shift to see the tooltip in the above screenshot